### PR TITLE
Checking file name for null C string

### DIFF
--- a/Bundle/GoogleTests.mm
+++ b/Bundle/GoogleTests.mm
@@ -45,7 +45,8 @@ public:
             return;
 
         int lineNumber = test_part_result.line_number();
-        NSString *path = [@(test_part_result.file_name()) stringByStandardizingPath];
+        const char *fileName = test_part_result.file_name();
+        NSString *path = fileName ? [@(fileName) stringByStandardizingPath] : nil;
         NSString *description = @(test_part_result.message());
         [_testCase recordFailureWithDescription:description
                                          inFile:path


### PR DESCRIPTION
If an unhandled C++ exception bubbles up to the test, and the OnTestPartResult handler gets a TestPartResult with a null C string for the filename, it crashes trying to convert it to an NSString. This adds a check to make sure it isn't null before the conversion.