### PR TITLE
Run all tests for current test class/fixture/suite only once

### DIFF
--- a/Bundle/GoogleTests.mm
+++ b/Bundle/GoogleTests.mm
@@ -150,7 +150,7 @@ private:
 
 /**
  *Run the tests in teardown method.
- *By now all the name of all the tests for current class will be part of @finalFilter
+ *By now the name of all the tests for current class will be part of @finalFilter
  */
 + (void)tearDown{
     RunAllTestsForCurrentClass(self);


### PR DESCRIPTION
This is to resolve this issue - [https://github.com/mattstevens/xcode-googletest/issues/6](url)

The idea is to create a Gtest filter for all the tests that are called for current class and then run those together to avoid calling SetUpTestCase multiple times.